### PR TITLE
Bump version to 2.2.0 for XDG directories feature

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-version", version: "2.1.0", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-version", version: "2.2.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()


### PR DESCRIPTION
## Summary
- Version bump to 2.2.0 as part of the XDG Base Directory migration across all core libraries

## Test plan
- [x] `sb test` passes (6 tests, 0 failures)